### PR TITLE
Return exception when using Connect.web.ts

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - boost (1.76.0)
   - Connect (0.1.0):
     - ExpoModulesCore
-    - MoneyKit (~> 1.1.6)
+    - MoneyKit (~> 1.1.7)
   - DoubleConversion (1.1.6)
   - EXApplication (5.3.1):
     - ExpoModulesCore
@@ -36,7 +36,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.72.6)
   - hermes-engine/Pre-built (0.72.6)
   - libevent (2.1.12)
-  - MoneyKit (1.1.6)
+  - MoneyKit (1.1.7)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -607,7 +607,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  Connect: 66f11b4b3eff77de5e321f3850e47d145c193f27
+  Connect: 9a40ef76a951fed70a2b67a70a2a9d64e2d4db91
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: 042aa2e3f05258a16962ea1a9914bf288db9c9a1
   EXConstants: ce5bbea779da8031ac818c36bea41b10e14d04e1
@@ -622,7 +622,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 8057e75cfc1437b178ac86c8654b24e7fead7f60
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  MoneyKit: df3b56d2243ac33f65164408b27a1efcc4d7d5ac
+  MoneyKit: 770aebdd18ff801e97614fb6fd094ba4cfcaf800
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 28469809442eb4eb5528462705f7d852948c8a74
   RCTTypeSafety: e9c6c409fca2cc584e5b086862d562540cb38d29

--- a/ios/Connect.podspec
+++ b/ios/Connect.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MoneyKit', '~> 1.1.6'
+  s.dependency 'MoneyKit', '~> 1.1.7'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/src/Connect.web.ts
+++ b/src/Connect.web.ts
@@ -1,5 +1,25 @@
 import { CodedError } from 'expo-modules-core';
 
+import { ConnectConfiguration } from "./Connect.types";
+
 export default {
- 
+    async presentInstitutionSelectionFlow({
+        onSuccess,
+        onExit,
+        onEvent,
+        linkSessionToken,
+      }: ConnectConfiguration) {
+        throw new CodedError('UNAVAILABLE', 'Connect not available');
+      },
+      async presentLinkFlow({
+        onSuccess,
+        onExit,
+        onEvent,
+        linkSessionToken,
+      }: ConnectConfiguration) {
+        throw new CodedError('UNAVAILABLE', 'Connect not available');
+      },
+      async continueFlow(url: string) {
+        throw new CodedError('UNAVAILABLE', 'Connect not available');
+      }
 };


### PR DESCRIPTION
This updates the Expo package to not support web. The `Connect.web.ts` has been updated to return errors.

I also bumped the iOS SDK to 1.1.7 so that we can serialise the events and success types correctly.