### PR TITLE
Remove broken expo links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,6 @@
-# @moneykit/connect-react-native
+# Connect React Native
 
 MoneyKit Connect is a quick and secure way to link bank accounts from within your app. The drop-in framework handles connecting to a financial institution in your app (credential validation, multi-factor authentication, error handling, etc.) without passing sensitive information to your server
-
-# API documentation
-
-- [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/moneykit-connect-react-native.md)
-- [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/moneykit-connect-react-native/)
-
-# Installation in managed Expo projects
-
-For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 # Installation in bare React Native projects
 
@@ -27,6 +18,4 @@ Run `npx pod-install` after installing the npm package.
 
 ### Configure for Android
 
-# Contributing
-
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).
+No additional set up necessary.


### PR DESCRIPTION
This removes the broken links Expo generated in the Readme