### PR TITLE
Launch SDK with single entry point

### DIFF
--- a/android/src/main/java/expo/modules/moneykitconnectreactnativesource/ConnectModule.kt
+++ b/android/src/main/java/expo/modules/moneykitconnectreactnativesource/ConnectModule.kt
@@ -46,12 +46,6 @@ class ConnectModule : Module() {
       "onExit",
     )
 
-    AsyncFunction("presentInstitutionSelectionFlow") { config: Configuration ->
-      linkHandler = createLinkHandler(config.linkSessionToken)
-
-      linkHandler?.presentInstitutionSelectionFlow(currentActivity)
-    }.runOnQueue(Queues.MAIN)
-
     AsyncFunction("presentLinkFlow") { config: Configuration ->
       linkHandler = createLinkHandler(config.linkSessionToken)
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,10 +1,10 @@
 import {
   ConnectConfiguration,
-  presentInstitutionSelectionFlow,
-  continueFlow,
+  presentLinkFlow,
+  continueFlow
 } from "@moneykit/connect-react-native";
+
 import * as Linking from "expo-linking";
-import { useEffect } from "react";
 import { StyleSheet, View } from "react-native";
 
 import Button from "./Button";
@@ -22,8 +22,8 @@ const config: ConnectConfiguration = {
   },
 };
 
-const presentConnectInstitutionSelectionFlow = () => {
-  presentInstitutionSelectionFlow(config);
+const presentMoneyKit = () => {
+  presentLinkFlow(config);
 };
 
 export default function App() {
@@ -37,7 +37,7 @@ export default function App() {
     <View style={styles.container}>
       <Button
         title="Connect a bank"
-        onPress={presentConnectInstitutionSelectionFlow}
+        onPress={presentMoneyKit}
       />
     </View>
   );

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,9 +1,8 @@
 import {
   ConnectConfiguration,
   presentLinkFlow,
-  continueFlow
+  continueFlow,
 } from "@moneykit/connect-react-native";
-
 import * as Linking from "expo-linking";
 import { StyleSheet, View } from "react-native";
 
@@ -35,10 +34,7 @@ export default function App() {
 
   return (
     <View style={styles.container}>
-      <Button
-        title="Connect a bank"
-        onPress={presentMoneyKit}
-      />
+      <Button title="Connect a bank" onPress={presentMoneyKit} />
     </View>
   );
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost (1.76.0)
-  - Connect (0.1.2):
+  - Connect (0.1.3):
     - ExpoModulesCore
     - MoneyKit (~> 1.1.9)
   - DoubleConversion (1.1.6)
@@ -694,7 +694,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  Connect: 296b38b60af71cbbe631c277aa551a9cc67c9f1d
+  Connect: b3b5b788004544348396e9b1be39a8b680c091ee
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: 042aa2e3f05258a16962ea1a9914bf288db9c9a1
   EXConstants: ce5bbea779da8031ac818c36bea41b10e14d04e1
@@ -755,4 +755,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 3e255dd4d3a04c550ab1b248d36042a8004c2e43
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.14.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - boost (1.76.0)
   - Connect (0.1.3):
     - ExpoModulesCore
-    - MoneyKit (~> 1.1.9)
+    - MoneyKit (~> 1.1.10)
   - DoubleConversion (1.1.6)
   - EXApplication (5.3.1):
     - ExpoModulesCore
@@ -99,7 +99,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.72.6)
   - hermes-engine/Pre-built (0.72.6)
   - libevent (2.1.12)
-  - MoneyKit (1.1.9)
+  - MoneyKit (1.1.10)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -694,7 +694,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  Connect: b3b5b788004544348396e9b1be39a8b680c091ee
+  Connect: 8f3f95627f9872fc80f04bb2e16799f1c5c49619
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: 042aa2e3f05258a16962ea1a9914bf288db9c9a1
   EXConstants: ce5bbea779da8031ac818c36bea41b10e14d04e1
@@ -717,7 +717,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 8057e75cfc1437b178ac86c8654b24e7fead7f60
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  MoneyKit: e1a6d7872ebf76387420587fc87b8ef6e2100728
+  MoneyKit: 7ed718679a2e9f84765d7e95257057366e11d3bd
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 28469809442eb4eb5528462705f7d852948c8a74
   RCTTypeSafety: e9c6c409fca2cc584e5b086862d562540cb38d29
@@ -755,4 +755,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 3e255dd4d3a04c550ab1b248d36042a8004c2e43
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/ios/Connect.podspec
+++ b/ios/Connect.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MoneyKit', '~> 1.1.9'
+  s.dependency 'MoneyKit', '~> 1.1.10'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@moneykit/connect-react-native",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "expo-modules-core": "~1.5.10"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,14 @@ const addListenerWithCleanup = (emitter: EventEmitter, eventName: string, listen
       listener(args);
       if (listenerSubscription) {
 
-        if (eventName !== "onEvent") {
-          listenerSubscription.remove();
-        }
+        console.log(`Count of onSuccess: `,emitter._eventEmitter.listenerCount("onSuccess"))
+        console.log(`Count of onExit: `,emitter._eventEmitter.listenerCount("onExit"))
+        console.log(`Count of onEvent: `,emitter._eventEmitter.listenerCount("onEvent"))
 
+        if (eventName !== "onEvent") {
+          emitter.removeAllListeners(eventName);
+        }
+  
         if (eventName === "onExit") {
           emitter.removeAllListeners("onSuccess");
         }
@@ -26,33 +30,24 @@ const addListenerWithCleanup = (emitter: EventEmitter, eventName: string, listen
   );
 };
 
-export async function presentInstitutionSelectionFlow({
-  onSuccess,
-  onExit,
-  onEvent,
-  linkSessionToken,
-}: ConnectConfiguration) {
-  const emitter = new EventEmitter(Connect);
-
-  addListenerWithCleanup(emitter, "onSuccess", onSuccess);
-  addListenerWithCleanup(emitter, "onExit", onExit);
-  if (onEvent) addListenerWithCleanup(emitter, "onEvent", onEvent);
-
-  return await Connect.presentInstitutionSelectionFlow({ linkSessionToken });
-}
-
 export async function presentLinkFlow({
   onSuccess,
   onExit,
   onEvent,
   linkSessionToken,
 }: ConnectConfiguration) {
+  console.log("Present Link Flow")
   const emitter = new EventEmitter(Connect);
 
   addListenerWithCleanup(emitter, "onSuccess", onSuccess);
   addListenerWithCleanup(emitter, "onExit", onExit);
+
   if (onEvent) addListenerWithCleanup(emitter, "onEvent", onEvent);
 
+  console.log(`Count of onSuccess: `,emitter._eventEmitter.listenerCount("onSuccess"))
+  console.log(`Count of onExit: `,emitter._eventEmitter.listenerCount("onExit"))
+  console.log(`Count of onEvent: `,emitter._eventEmitter.listenerCount("onEvent"))
+  
   return await Connect.presentLinkFlow({ linkSessionToken });
 }
 


### PR DESCRIPTION
Previously the SDK had two functions to start a link:

- `presentInstitutionSelectionFlow`
- `presentLinkFlow`

This followed the native iOS SDK as it has levels of customisation that can be applied to the institution selection flow. These customisations are not available in the react native SDK therefore we have unified the API to be a single entry point to keep things simple.

We have also re-worked the event emitter code in order to try and prevent any crashes.