### PR TITLE
Update MoneyKit Connect SDK version

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - boost (1.76.0)
-  - Connect (0.1.4):
+  - Connect (0.1.5):
     - ExpoModulesCore
-    - MoneyKit (~> 1.1.10)
+    - MoneyKit (~> 1.1.11)
   - DoubleConversion (1.1.6)
   - EXApplication (5.3.1):
     - ExpoModulesCore
@@ -99,7 +99,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.72.6)
   - hermes-engine/Pre-built (0.72.6)
   - libevent (2.1.12)
-  - MoneyKit (1.1.10)
+  - MoneyKit (1.1.11)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -694,7 +694,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  Connect: c6323ef6290e68b525f35a6f7405cd935b0e8502
+  Connect: 36d4875615eb4ee828350715712e7d68f46106f4
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: 042aa2e3f05258a16962ea1a9914bf288db9c9a1
   EXConstants: ce5bbea779da8031ac818c36bea41b10e14d04e1
@@ -717,7 +717,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 8057e75cfc1437b178ac86c8654b24e7fead7f60
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  MoneyKit: 7ed718679a2e9f84765d7e95257057366e11d3bd
+  MoneyKit: 6b410e5a1c04812a458940f088587affc4eb4329
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 28469809442eb4eb5528462705f7d852948c8a74
   RCTTypeSafety: e9c6c409fca2cc584e5b086862d562540cb38d29

--- a/ios/Connect.podspec
+++ b/ios/Connect.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MoneyKit', '~> 1.1.10'
+  s.dependency 'MoneyKit', '~> 1.1.11'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/ios/ConnectModule.swift
+++ b/ios/ConnectModule.swift
@@ -94,7 +94,7 @@ public class ConnectModule: Module {
     private func handleConnectExit(error: MKLinkError?) {
         if let error = error {
             sendEvent(self.onExit, [
-                "identifier": error.identifier,
+                "identifier": error.errorId,
                 "displayedMessage": error.displayedMessage,
                 "requestId": error.requestId
             ])

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "moneykit",
     "connect"
   ],
-  "repository": "https://github.com/moneykit/moneykit-connect-react-native",
+  "repository": "https://github.com/moneykit/moneykit-react-native",
   "bugs": {
-    "url": "https://github.com/moneykit/moneykit-connect-react-native/issues"
+    "url": "https://github.com/moneykit/moneykit-react-native/issues"
   },
   "author": "MoneyKit <info@moneykit.com> (https://github.com/moneykit)",
   "license": "MIT",
-  "homepage": "https://github.com/moneykit/moneykit-connect-react-native#readme",
+  "homepage": "https://github.com/moneykit/moneykit-react-native#readme",
   "dependencies": {
     "expo-modules-core": "~1.5.10"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "description": "MoneyKit Connect is a quick and secure way to link bank accounts from within your app. The drop-in framework handles connecting to a financial institution in your app (credential validation, multi-factor authentication, error handling, etc.) without passing sensitive information to your server",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
This updates to the latest MoneyKit Connect IOS Framework which has a fix for a relinking crash.