### PR TITLE
Update MoneyKit SDK to 1.3.0

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - boost (1.76.0)
-  - Connect (1.2.0):
+  - Connect (1.2.2):
     - ExpoModulesCore
-    - MoneyKit (~> 1.2.2)
+    - MoneyKit (~> 1.3.0)
   - DoubleConversion (1.1.6)
   - EXApplication (5.3.1):
     - ExpoModulesCore
@@ -99,7 +99,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.72.6)
   - hermes-engine/Pre-built (0.72.6)
   - libevent (2.1.12)
-  - MoneyKit (1.2.2)
+  - MoneyKit (1.3.0)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -694,7 +694,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  Connect: b354d19626c3b5b11d9ede39b4c98ffb3f153d6a
+  Connect: 2bdc1e0439ed48a1ac54e9aad723e46ec1f65055
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: 042aa2e3f05258a16962ea1a9914bf288db9c9a1
   EXConstants: ce5bbea779da8031ac818c36bea41b10e14d04e1
@@ -717,7 +717,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 8057e75cfc1437b178ac86c8654b24e7fead7f60
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  MoneyKit: dc6ea8398445e4b38e5b865a9a1f84bf7ba00090
+  MoneyKit: 2b15a77387a85b1e13a62c20aa5d1a32027ea4ee
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 28469809442eb4eb5528462705f7d852948c8a74
   RCTTypeSafety: e9c6c409fca2cc584e5b086862d562540cb38d29

--- a/ios/Connect.podspec
+++ b/ios/Connect.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MoneyKit', '~> 1.2.2'
+  s.dependency 'MoneyKit', '~> 1.3.0'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/ios/ConnectModule.swift
+++ b/ios/ConnectModule.swift
@@ -33,11 +33,7 @@ public class ConnectModule: Module {
                 throw MissingCurrentViewControllerException()
             }
 
-            if try self.canSkipInstitutionSelection(for: value.linkSessionToken) {
-                self.linkHandler?.presentLinkFlow(on: currentViewcontroller)
-            } else {
-                self.linkHandler?.presentInstitutionSelectionFlow(using: .modal(presentingViewController: currentViewcontroller))
-            }
+            self.linkHandler?.presentLinkFlow(on: currentViewcontroller)
         }
         .runOnQueue(.main)
 
@@ -109,12 +105,6 @@ public class ConnectModule: Module {
             "meta": event.meta,
             "properties": event.properties
         ])
-    }
-
-    private func canSkipInstitutionSelection(for token: String) throws -> Bool {
-        let jwtToken = try ConnectTokenDecoder.decodeToken(token)
-
-        return jwtToken.header["institution_id"] as? String != nil
     }
 
     private func serialize(_ object: Codable) -> [String: Any]? {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "MoneyKit Connect is a quick and secure way to link bank accounts from within your app. The drop-in framework handles connecting to a financial institution in your app (credential validation, multi-factor authentication, error handling, etc.) without passing sensitive information to your server",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
This bumps the React Native SDK to version 1.2.2

This includes the latest [iOS SDK release](https://github.com/moneykit/moneykit-ios/releases/tag/1.3.0). There were no breaking changes in this release, we were able to remove the conditional checks on the link session token as the latest iOS SDK has merged its flow entry point.