### PR TITLE
Update MoneyKit SDKs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,5 +86,5 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "com.moneykit:connect:0.0.4"
+  implementation "com.moneykit:connect:0.0.5"
 }

--- a/android/src/main/java/expo/modules/moneykitconnectreactnativesource/ConnectModule.kt
+++ b/android/src/main/java/expo/modules/moneykitconnectreactnativesource/ConnectModule.kt
@@ -1,5 +1,6 @@
 package expo.modules.moneykitconnectreactnative
 
+import android.content.Context
 import android.net.Uri
 import com.moneykit.connect.MkConfiguration
 import com.moneykit.connect.MkLinkHandler
@@ -23,6 +24,9 @@ class Configuration: Record {
 class ConnectModule : Module() {
   private val currentActivity
     get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
+
+  private val context: Context
+    get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
 
   private var linkHandler: MkLinkHandler? = null
 
@@ -54,7 +58,7 @@ class ConnectModule : Module() {
 
     AsyncFunction("continueFlow") { urlString: String ->
       val url = Uri.parse(urlString)
-      linkHandler?.continueFlow(url)
+      linkHandler?.continueFlow(context, url)
     }.runOnQueue(Queues.MAIN)
   }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - boost (1.76.0)
-  - Connect (1.2.2):
+  - Connect (1.3.0):
     - ExpoModulesCore
-    - MoneyKit (~> 1.3.0)
+    - MoneyKit (~> 1.3.1)
   - DoubleConversion (1.1.6)
   - EXApplication (5.3.1):
     - ExpoModulesCore
@@ -99,7 +99,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.72.6)
   - hermes-engine/Pre-built (0.72.6)
   - libevent (2.1.12)
-  - MoneyKit (1.3.0)
+  - MoneyKit (1.3.1)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -694,7 +694,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  Connect: 2bdc1e0439ed48a1ac54e9aad723e46ec1f65055
+  Connect: 2a894530a3a236d51c8acccc67fd9a8323317fad
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: 042aa2e3f05258a16962ea1a9914bf288db9c9a1
   EXConstants: ce5bbea779da8031ac818c36bea41b10e14d04e1
@@ -717,7 +717,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 8057e75cfc1437b178ac86c8654b24e7fead7f60
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  MoneyKit: 2b15a77387a85b1e13a62c20aa5d1a32027ea4ee
+  MoneyKit: 02161632c29fc5aa4e2ea00943388727a4c77c6c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 28469809442eb4eb5528462705f7d852948c8a74
   RCTTypeSafety: e9c6c409fca2cc584e5b086862d562540cb38d29

--- a/ios/Connect.podspec
+++ b/ios/Connect.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MoneyKit', '~> 1.3.0'
+  s.dependency 'MoneyKit', '~> 1.3.1'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "MoneyKit Connect is a quick and secure way to link bank accounts from within your app. The drop-in framework handles connecting to a financial institution in your app (credential validation, multi-factor authentication, error handling, etc.) without passing sensitive information to your server",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
This bumps the React Native SDK to version 1.3.0

This includes the latest [iOS SDK release](https://github.com/moneykit/moneykit-ios/releases/tag/1.3.1). There were no breaking changes in this release.

This also includes the latest [Android SDK release](https://central.sonatype.com/artifact/com.moneykit/connect/0.0.5/versions). There were no breaking changes in this release.