### PR TITLE
Update MoneyKit iOS SDK to 1.5.0

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -7,7 +7,7 @@ podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties
 ENV['RCT_NEW_ARCH_ENABLED'] = podfile_properties['newArchEnabled'] == 'true' ? '1' : '0'
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 
-platform :ios, podfile_properties['ios.deploymentTarget'] || '13.0'
+platform :ios, podfile_properties['ios.deploymentTarget'] || '14.0'
 install! 'cocoapods',
   :deterministic_uuids => false
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - boost (1.76.0)
   - Connect (1.4.0):
     - ExpoModulesCore
-    - MoneyKit (~> 1.4.0)
+    - MoneyKit (~> 1.5.0)
   - DoubleConversion (1.1.6)
   - EXApplication (5.3.1):
     - ExpoModulesCore
@@ -99,7 +99,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.72.6)
   - hermes-engine/Pre-built (0.72.6)
   - libevent (2.1.12)
-  - MoneyKit (1.4.0)
+  - MoneyKit (1.5.0)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -694,7 +694,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  Connect: dd3f3086433f69d41482eb00261613efb7203295
+  Connect: ec55932ad1480cb27d7ac959db08fe2d4f17dc58
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXApplication: 042aa2e3f05258a16962ea1a9914bf288db9c9a1
   EXConstants: ce5bbea779da8031ac818c36bea41b10e14d04e1
@@ -717,7 +717,7 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 8057e75cfc1437b178ac86c8654b24e7fead7f60
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  MoneyKit: 0d9bd13876af73cf395c51cc944468291669acca
+  MoneyKit: cd1dc68419347fef5c7b83089eb4c5eaaca49c75
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 28469809442eb4eb5528462705f7d852948c8a74
   RCTTypeSafety: e9c6c409fca2cc584e5b086862d562540cb38d29
@@ -753,6 +753,6 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: b76f1acfda8212aa16b7e26bcce3983230c82603
 
-PODFILE CHECKSUM: 3e255dd4d3a04c550ab1b248d36042a8004c2e43
+PODFILE CHECKSUM: 85de3d253d4708981dcae24091c53f9f0ca17e3f
 
 COCOAPODS: 1.14.3

--- a/example/ios/moneykitconnectreactnativeexample.xcodeproj/project.pbxproj
+++ b/example/ios/moneykitconnectreactnativeexample.xcodeproj/project.pbxproj
@@ -359,7 +359,7 @@
 					"FB_SONARKIT_ENABLED=1",
 				);
 				INFOPLIST_FILE = moneykitconnectreactnativeexample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -394,7 +394,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 96G9TF54YX;
 				INFOPLIST_FILE = moneykitconnectreactnativeexample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/Connect.podspec
+++ b/ios/Connect.podspec
@@ -10,13 +10,13 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.0'
+  s.platform       = :ios, '14.0'
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/moneykit/moneykit-connect-react-native' }
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MoneyKit', '~> 1.4.0'
+  s.dependency 'MoneyKit', '~> 1.5.0'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "0.1.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@moneykit/connect-react-native",
-      "version": "0.1.3",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "expo-modules-core": "~1.5.10"
       },
       "devDependencies": {
-        "@types/react": "^18.0.25",
+        "@types/react": "~18.2.45",
         "expo-module-scripts": "^3.0.11",
         "expo-modules-core": "^1.5.11"
       },
       "peerDependencies": {
-        "expo": "*",
+        "expo": "^50.0.7",
         "react": "*",
         "react-native": "*"
       }
@@ -778,6 +778,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz",
       "integrity": "sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==",
       "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-export-namespace-from instead.",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.9",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
@@ -1795,6 +1796,21 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz",
+      "integrity": "sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==",
+      "peer": true,
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.23.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.23.3.tgz",
@@ -1814,6 +1830,22 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.23.3.tgz",
       "integrity": "sha512-91RS0MDnAWDNvGC6Wio5XYkyWI39FMFO+JK9+4AlgaTH+yWwVTsw7/sn6LK0lH7c5F+TFkpv/3LfCJ1Ydwof/g==",
       "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.23.3.tgz",
+      "integrity": "sha512-qMFdSS+TUhB7Q/3HVPnEdYJDQIk57jkntAwSuz9xfSE4n+3I+vHYCli3HoHawN1Z3RfCz/y1zXA/JXjG6cVImQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
@@ -2155,6 +2187,26 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.23.3.tgz",
+      "integrity": "sha512-tbkHOS9axH6Ysf2OUEqoSZ6T3Fa2SrNH6WTWSPBboxKzdxNc9qOICeLXkNG0ZEwbQ1HY8liwOce4aN/Ceyuq6w==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-validator-option": "^7.22.15",
+        "@babel/plugin-transform-react-display-name": "^7.23.3",
+        "@babel/plugin-transform-react-jsx": "^7.22.15",
+        "@babel/plugin-transform-react-jsx-development": "^7.22.5",
+        "@babel/plugin-transform-react-pure-annotations": "^7.23.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-typescript": {
@@ -2549,77 +2601,82 @@
         "safe-json-stringify": "~1"
       }
     },
-    "node_modules/@expo/bunyan/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@expo/cli": {
-      "version": "0.10.15",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.10.15.tgz",
-      "integrity": "sha512-CIpfIB5oB/s/op6Ke5M7TI4/yOi5raTR9ps9UD+ExazonTDAzEtXANVWmAR7Z4+wUyqycniWxTpICcaxri2a3A==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.17.5.tgz",
+      "integrity": "sha512-9cMquL/5bBfV73CbZcWipk3KZSo8mBqdgvkoWCtEtnnlm/879ayxzMWjVIgT5yV4w+X7+N6KkBSUIIj4t9Xqew==",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/code-signing-certificates": "0.0.5",
-        "@expo/config": "~8.1.0",
-        "@expo/config-plugins": "~7.2.0",
-        "@expo/dev-server": "0.5.5",
+        "@expo/config": "~8.5.0",
+        "@expo/config-plugins": "~7.8.0",
         "@expo/devcert": "^1.0.0",
-        "@expo/env": "0.0.5",
+        "@expo/env": "~0.2.0",
+        "@expo/image-utils": "^0.4.0",
         "@expo/json-file": "^8.2.37",
-        "@expo/metro-config": "~0.10.0",
+        "@expo/metro-config": "~0.17.0",
         "@expo/osascript": "^2.0.31",
-        "@expo/package-manager": "~1.1.0",
-        "@expo/plist": "^0.0.20",
-        "@expo/prebuild-config": "6.2.6",
+        "@expo/package-manager": "^1.1.1",
+        "@expo/plist": "^0.1.0",
+        "@expo/prebuild-config": "6.7.4",
         "@expo/rudder-sdk-node": "1.1.1",
         "@expo/spawn-async": "1.5.0",
-        "@expo/xcpretty": "^4.2.1",
+        "@expo/xcpretty": "^4.3.0",
+        "@react-native/dev-middleware": "^0.73.6",
         "@urql/core": "2.3.6",
         "@urql/exchange-retry": "0.3.0",
         "accepts": "^1.3.8",
-        "arg": "4.1.0",
+        "arg": "5.0.2",
         "better-opn": "~3.0.2",
         "bplist-parser": "^0.3.1",
         "cacache": "^15.3.0",
         "chalk": "^4.0.0",
         "ci-info": "^3.3.0",
+        "connect": "^3.7.0",
         "debug": "^4.3.4",
         "env-editor": "^0.4.1",
+        "find-yarn-workspace-root": "~2.0.0",
         "form-data": "^3.0.1",
         "freeport-async": "2.0.0",
         "fs-extra": "~8.1.0",
         "getenv": "^1.0.0",
+        "glob": "^7.1.7",
         "graphql": "15.8.0",
         "graphql-tag": "^2.10.1",
         "https-proxy-agent": "^5.0.1",
         "internal-ip": "4.3.0",
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1",
         "js-yaml": "^3.13.1",
         "json-schema-deref-sync": "^0.13.0",
-        "md5-file": "^3.2.3",
+        "lodash.debounce": "^4.0.8",
         "md5hex": "^1.0.0",
-        "minipass": "3.1.6",
+        "minimatch": "^3.0.4",
+        "minipass": "3.3.6",
         "node-fetch": "^2.6.7",
         "node-forge": "^1.3.1",
         "npm-package-arg": "^7.0.0",
+        "open": "^8.3.0",
         "ora": "3.4.0",
+        "picomatch": "^3.0.1",
         "pretty-bytes": "5.6.0",
         "progress": "2.0.3",
         "prompts": "^2.3.2",
         "qrcode-terminal": "0.11.0",
         "require-from-string": "^2.0.2",
         "requireg": "^0.2.2",
+        "resolve": "^1.22.2",
         "resolve-from": "^5.0.0",
+        "resolve.exports": "^2.0.2",
         "semver": "^7.5.3",
         "send": "^0.18.0",
         "slugify": "^1.3.4",
+        "source-map-support": "~0.5.21",
+        "stacktrace-parser": "^0.1.10",
         "structured-headers": "^0.4.1",
         "tar": "^6.0.5",
+        "temp-dir": "^2.0.0",
         "tempy": "^0.7.1",
         "terminal-link": "^2.1.1",
         "text-table": "^0.2.0",
@@ -2629,6 +2686,59 @@
       },
       "bin": {
         "expo-internal": "build/bin/cli"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/@expo/plist": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.1.0.tgz",
+      "integrity": "sha512-xWD+8vIFif0wKyuqe3fmnmnSouXYucciZXFzS0ZD5OV9eSAS1RGQI5FaGGJ6zxJ4mpdy/4QzbLdBjnYE5vxA0g==",
+      "peer": true,
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.7",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/picomatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
+      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/@expo/code-signing-certificates": {
@@ -2642,14 +2752,14 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-8.1.2.tgz",
-      "integrity": "sha512-4e7hzPj50mQIlsrzOH6XZ36O094mPfPTIDIH4yv49bWNMc7GFLTofB/lcT+QyxiLaJuC0Wlk9yOLB8DIqmtwug==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-8.5.4.tgz",
+      "integrity": "sha512-ggOLJPHGzJSJHVBC1LzwXwR6qUn8Mw7hkc5zEKRIdhFRuIQ6s2FE4eOvP87LrNfDF7eZGa6tJQYsiHSmZKG+8Q==",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~7.2.0",
-        "@expo/config-types": "^49.0.0-alpha.1",
+        "@expo/config-plugins": "~7.8.2",
+        "@expo/config-types": "^50.0.0",
         "@expo/json-file": "^8.2.37",
         "getenv": "^1.0.0",
         "glob": "7.1.6",
@@ -2657,18 +2767,19 @@
         "resolve-from": "^5.0.0",
         "semver": "7.5.3",
         "slugify": "^1.3.4",
-        "sucrase": "^3.20.0"
+        "sucrase": "3.34.0"
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.2.5.tgz",
-      "integrity": "sha512-w+5ccu1IxBHgyQk9CPFKLZOk8yZQEyTjbJwOzESK1eR7QwosbcsLkN1c1WWUZYiCXwORu3UTwJYll4+X2xxJhQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.8.4.tgz",
+      "integrity": "sha512-hv03HYxb/5kX8Gxv/BTI8TLc9L06WzqAfHRRXdbar4zkLcP2oTzvsLEF4/L/TIpD3rsnYa0KU42d0gWRxzPCJg==",
       "peer": true,
       "dependencies": {
-        "@expo/config-types": "^49.0.0-alpha.1",
-        "@expo/json-file": "~8.2.37",
-        "@expo/plist": "^0.0.20",
+        "@expo/config-types": "^50.0.0-alpha.1",
+        "@expo/fingerprint": "^0.6.0",
+        "@expo/json-file": "~8.3.0",
+        "@expo/plist": "^0.1.0",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "@react-native/normalize-color": "^2.0.0",
         "chalk": "^4.1.2",
@@ -2679,15 +2790,55 @@
         "resolve-from": "^5.0.0",
         "semver": "^7.5.3",
         "slash": "^3.0.0",
+        "slugify": "^1.6.6",
         "xcode": "^3.0.1",
         "xml2js": "0.6.0"
       }
     },
+    "node_modules/@expo/config-plugins/node_modules/@expo/fingerprint": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.6.0.tgz",
+      "integrity": "sha512-KfpoVRTMwMNJ/Cf5o+Ou8M/Y0EGSTqK+rbi70M2Y0K2qgWNfMJ1gm6sYO9uc8lcTr7YSYM1Rme3dk7QXhpScNA==",
+      "peer": true,
+      "dependencies": {
+        "@expo/spawn-async": "^1.5.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "find-up": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "p-limit": "^3.1.0",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "fingerprint": "bin/cli.js"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/@expo/json-file": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.3.0.tgz",
+      "integrity": "sha512-yROUeXJXR5goagB8c3muFLCzLmdGOvoPpR5yDNaXrnTp4euNykr9yW0wWhJx4YVRTNOPtGBnEbbJBW+a9q+S6g==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.2",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/@expo/plist": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.1.0.tgz",
+      "integrity": "sha512-xWD+8vIFif0wKyuqe3fmnmnSouXYucciZXFzS0ZD5OV9eSAS1RGQI5FaGGJ6zxJ4mpdy/4QzbLdBjnYE5vxA0g==",
+      "peer": true,
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.7",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
     "node_modules/@expo/config-types": {
-      "version": "49.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-49.0.0.tgz",
-      "integrity": "sha512-8eyREVi+K2acnMBe/rTIu1dOfyR2+AMnTLHlut+YpMV9OZPdeKV0Bs9BxAewGqBA2slslbQ9N39IS2CuTKpXkA==",
-      "peer": true
+      "version": "50.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-50.0.0.tgz",
+      "integrity": "sha512-0kkhIwXRT6EdFDwn+zTg9R2MZIAEYGn1MVkyRohAd+C9cXOb5RA8WLQi7vuxKF9m1SMtNAUrf0pO+ENK0+/KSw=="
     },
     "node_modules/@expo/config/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -2722,74 +2873,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "peer": true
     },
-    "node_modules/@expo/dev-server": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.5.5.tgz",
-      "integrity": "sha512-t0fT8xH1exwYsH5hh7bAt85VF+gXxg24qrbny2rR/iKoPTWFCd2JNQV8pvfLg51hvrywQ3YCBuT3lU1w7aZxFA==",
-      "peer": true,
-      "dependencies": {
-        "@expo/bunyan": "4.0.0",
-        "@expo/metro-config": "~0.10.0",
-        "@expo/osascript": "2.0.33",
-        "@expo/spawn-async": "^1.5.0",
-        "body-parser": "^1.20.1",
-        "chalk": "^4.0.0",
-        "connect": "^3.7.0",
-        "fs-extra": "9.0.0",
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1",
-        "node-fetch": "^2.6.0",
-        "open": "^8.3.0",
-        "resolve-from": "^5.0.0",
-        "serialize-error": "6.0.0",
-        "temp-dir": "^2.0.0"
-      }
-    },
-    "node_modules/@expo/dev-server/node_modules/fs-extra": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-      "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-      "peer": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@expo/dev-server/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@expo/dev-server/node_modules/jsonfile/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@expo/dev-server/node_modules/universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@expo/devcert": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@expo/devcert/-/devcert-1.1.0.tgz",
@@ -2821,9 +2904,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-0.0.5.tgz",
-      "integrity": "sha512-UXuKAqyXfhMQC3gP0OyjXmFX08Z1fkVWiGBN7bYzfoX8LHatjeHrDtI6w5nDvd8XPxPvmqaZoEDw1lW3+dz3oQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-0.2.1.tgz",
+      "integrity": "sha512-deZmRS7Dvp18VM8s559dq/ZjPlV1D9vtLoLXwHmCK/JYOvtNptdKsfxcWjI7ewmo6ln2PqgNI9HRI74q6Wk2eA==",
       "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -2852,9 +2935,9 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.3.22.tgz",
-      "integrity": "sha512-uzq+RERAtkWypOFOLssFnXXqEqKjNj9eXN7e97d/EXUAojNcLDoXc0sL+F5B1I4qtlsnhX01kcpoIBBZD8wZNQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.4.1.tgz",
+      "integrity": "sha512-EZb+VHSmw+a5s2hS9qksTcWylY0FDaIAVufcxoaRS9tHIXLjW5zcKW7Rhj9dSEbZbRVy9yXXdHKa3GQdUQIOFw==",
       "peer": true,
       "dependencies": {
         "@expo/spawn-async": "1.5.0",
@@ -2862,7 +2945,6 @@
         "fs-extra": "9.0.0",
         "getenv": "^1.0.0",
         "jimp-compact": "0.16.1",
-        "mime": "^2.4.4",
         "node-fetch": "^2.6.0",
         "parse-png": "^2.1.0",
         "resolve-from": "^5.0.0",
@@ -2991,23 +3073,172 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.10.7.tgz",
-      "integrity": "sha512-uACymEiyX0447hI4unt+2cemLQkTZXKvTev936NhtsgVnql45EP0V0pzmo/0H0WlHaAGXgvOBZJl8wFqcJ3CbQ==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.17.4.tgz",
+      "integrity": "sha512-PxqDMuVjXQeboa6Aj8kNj4iTxIpwpfoYlF803qOjf1LE1ePlREnWNwqy65ESCBnCmekYIO5hhm1Nksa+xCvuyg==",
       "peer": true,
       "dependencies": {
-        "@expo/config": "~8.1.0",
-        "@expo/env": "0.0.5",
-        "@expo/json-file": "~8.2.37",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.5",
+        "@babel/parser": "^7.20.0",
+        "@babel/types": "^7.20.0",
+        "@expo/config": "~8.5.0",
+        "@expo/env": "~0.2.0",
+        "@expo/json-file": "~8.3.0",
+        "@expo/spawn-async": "^1.7.2",
+        "babel-preset-fbjs": "^3.4.0",
         "chalk": "^4.1.0",
         "debug": "^4.3.2",
         "find-yarn-workspace-root": "~2.0.0",
+        "fs-extra": "^9.1.0",
         "getenv": "^1.0.0",
+        "glob": "^7.2.3",
         "jsc-safe-url": "^0.2.4",
         "lightningcss": "~1.19.0",
-        "postcss": "~8.4.21",
+        "postcss": "~8.4.32",
         "resolve-from": "^5.0.0",
-        "sucrase": "^3.20.0"
+        "sucrase": "3.34.0"
+      },
+      "peerDependencies": {
+        "@react-native/babel-preset": "*"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/json-file": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.3.0.tgz",
+      "integrity": "sha512-yROUeXJXR5goagB8c3muFLCzLmdGOvoPpR5yDNaXrnTp4euNykr9yW0wWhJx4YVRTNOPtGBnEbbJBW+a9q+S6g==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.2",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/spawn-async": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
+      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "peer": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@expo/npm-proofread": {
@@ -3032,9 +3263,9 @@
       }
     },
     "node_modules/@expo/osascript": {
-      "version": "2.0.33",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.0.33.tgz",
-      "integrity": "sha512-FQinlwHrTlJbntp8a7NAlCKedVXe06Va/0DSLXRO8lZVtgbEMrYYSUZWQNcOlNtc58c2elNph6z9dMOYwSo3JQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.1.0.tgz",
+      "integrity": "sha512-bOhuFnlRaS7CU33+rFFIWdcET/Vkyn1vsN8BYFwCDEF5P1fVVvYN7bFOsQLTMD3nvi35C1AGmtqUr/Wfv8Xaow==",
       "peer": true,
       "dependencies": {
         "@expo/spawn-async": "^1.5.0",
@@ -3045,9 +3276,9 @@
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.1.2.tgz",
-      "integrity": "sha512-JI9XzrxB0QVXysyuJ996FPCJGDCYRkbUvgG4QmMTTMFA1T+mv8YzazC3T9C1pHQUAAveVCre1+Pqv0nZXN24Xg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.4.2.tgz",
+      "integrity": "sha512-LKdo/6y4W7llZ6ghsg1kdx2CeH/qR/c6QI/JI8oPUvppsZoeIYjSkdflce978fAMfR8IXoi0wt0jA2w0kWpwbg==",
       "peer": true,
       "dependencies": {
         "@expo/json-file": "^8.2.37",
@@ -3059,6 +3290,7 @@
         "js-yaml": "^3.13.1",
         "micromatch": "^4.0.2",
         "npm-package-arg": "^7.0.0",
+        "ora": "^3.4.0",
         "split": "^1.0.1",
         "sudo-prompt": "9.1.1"
       }
@@ -3073,6 +3305,7 @@
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.0.20.tgz",
       "integrity": "sha512-UXQ4LXCfTZ580LDHGJ5q62jSTwJFFJ1GqBu8duQMThiHKWbMJ+gajJh6rsB6EJ3aLUr9wcauxneL5LVRFxwBEA==",
+      "dev": true,
       "dependencies": {
         "@xmldom/xmldom": "~0.7.7",
         "base64-js": "^1.2.3",
@@ -3080,15 +3313,15 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-6.2.6.tgz",
-      "integrity": "sha512-uFVvDAm9dPg9p1qpnr4CVnpo2hmkZIL5FQz+VlIdXXJpe7ySh/qTGHtKWY/lWUshQkAJ0nwbKGPztGWdABns/Q==",
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-6.7.4.tgz",
+      "integrity": "sha512-x8EUdCa8DTMZ/dtEXjHAdlP+ljf6oSeSKNzhycXiHhpMSMG9jEhV28ocCwc6cKsjK5GziweEiHwvrj6+vsBlhA==",
       "peer": true,
       "dependencies": {
-        "@expo/config": "~8.1.0",
-        "@expo/config-plugins": "~7.2.0",
-        "@expo/config-types": "^49.0.0-alpha.1",
-        "@expo/image-utils": "0.3.22",
+        "@expo/config": "~8.5.0",
+        "@expo/config-plugins": "~7.8.0",
+        "@expo/config-types": "^50.0.0-alpha.1",
+        "@expo/image-utils": "^0.4.0",
         "@expo/json-file": "^8.2.37",
         "debug": "^4.3.1",
         "fs-extra": "^9.0.0",
@@ -3187,15 +3420,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@expo/rudder-sdk-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@expo/sdk-runtime-versions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz",
@@ -3213,15 +3437,15 @@
       }
     },
     "node_modules/@expo/vector-icons": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-13.0.0.tgz",
-      "integrity": "sha512-TI+l71+5aSKnShYclFa14Kum+hQMZ86b95SH6tQUG3qZEmLTarvWpKwqtTwQKqvlJSJrpFiSFu3eCuZokY6zWA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-14.0.0.tgz",
+      "integrity": "sha512-5orm59pdnBQlovhU9k4DbjMUZBHNlku7IRgFY56f7pcaaCnXq9yaLJoOQl9sMwNdFzf4gnkTyHmR5uN10mI9rA==",
       "peer": true
     },
     "node_modules/@expo/xcpretty": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.2.2.tgz",
-      "integrity": "sha512-Lke/geldJqUV0Dfxg5/QIOugOzdqZ/rQ9yHKSgGbjZtG1uiSqWyFwWvXmrdd3/sIdX33eykGvIcf+OrvvcXVUw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.3.1.tgz",
+      "integrity": "sha512-sqXgo1SCv+j4VtYEwl/bukuOIBrVgx6euIoCat3Iyx5oeoXwEA2USCoeL0IPubflMxncA2INkqJ/Wr3NGrSgzw==",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.10.4",
@@ -3316,6 +3540,15 @@
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -5395,6 +5628,104 @@
       "integrity": "sha512-Im93xRJuHHxb1wniGhBMsxLwcfzdYreSZVQGDoMJgkd6+Iky61LInGEHnQCTN0fKNYF1Dvcofb4uMmE1RQHXHQ==",
       "peer": true
     },
+    "node_modules/@react-native/babel-plugin-codegen": {
+      "version": "0.73.4",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.73.4.tgz",
+      "integrity": "sha512-XzRd8MJGo4Zc5KsphDHBYJzS1ryOHg8I2gOZDAUCGcwLFhdyGu1zBNDJYH2GFyDrInn9TzAbRIf3d4O+eltXQQ==",
+      "peer": true,
+      "dependencies": {
+        "@react-native/codegen": "0.73.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/@react-native/codegen": {
+      "version": "0.73.3",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.73.3.tgz",
+      "integrity": "sha512-sxslCAAb8kM06vGy9Jyh4TtvjhcP36k/rvj2QE2Jdhdm61KvfafCATSIsOfc0QvnduWFcpXUPvAVyYwuv7PYDg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.0",
+        "flow-parser": "^0.206.0",
+        "glob": "^7.1.1",
+        "invariant": "^2.2.4",
+        "jscodeshift": "^0.14.0",
+        "mkdirp": "^0.5.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      }
+    },
+    "node_modules/@react-native/babel-preset": {
+      "version": "0.73.21",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.73.21.tgz",
+      "integrity": "sha512-WlFttNnySKQMeujN09fRmrdWqh46QyJluM5jdtDNrkl/2Hx6N4XeDUGhABvConeK95OidVO7sFFf7sNebVXogA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/core": "^7.20.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+        "@babel/plugin-proposal-class-properties": "^7.18.0",
+        "@babel/plugin-proposal-export-default-from": "^7.0.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.0",
+        "@babel/plugin-proposal-numeric-separator": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.20.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-export-default-from": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.18.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-to-generator": "^7.20.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.20.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.20.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-private-methods": "^7.22.5",
+        "@babel/plugin-transform-private-property-in-object": "^7.22.11",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
+        "@babel/plugin-transform-runtime": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.5.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@react-native/babel-plugin-codegen": "0.73.4",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
+        "react-refresh": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/babel-preset/node_modules/react-refresh": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@react-native/codegen": {
       "version": "0.72.7",
       "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.72.7.tgz",
@@ -5408,6 +5739,77 @@
       },
       "peerDependencies": {
         "@babel/preset-env": "^7.1.6"
+      }
+    },
+    "node_modules/@react-native/debugger-frontend": {
+      "version": "0.73.3",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.73.3.tgz",
+      "integrity": "sha512-RgEKnWuoo54dh7gQhV7kvzKhXZEhpF9LlMdZolyhGxHsBqZ2gXdibfDlfcARFFifPIiaZ3lXuOVVa4ei+uPgTw==",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/dev-middleware": {
+      "version": "0.73.8",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.73.8.tgz",
+      "integrity": "sha512-oph4NamCIxkMfUL/fYtSsE+JbGOnrlawfQ0kKtDQ5xbOjPKotKoXqrs1eGwozNKv7FfQ393stk1by9a6DyASSg==",
+      "peer": true,
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.73.3",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^1.0.0",
+        "connect": "^3.6.5",
+        "debug": "^2.2.0",
+        "node-fetch": "^2.2.0",
+        "open": "^7.0.3",
+        "serve-static": "^1.13.1",
+        "temp-dir": "^2.0.0",
+        "ws": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "peer": true
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "peer": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@react-native/dev-middleware/node_modules/ws": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "peer": true,
+      "dependencies": {
+        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/@react-native/gradle-plugin": {
@@ -5693,9 +6095,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.38.tgz",
-      "integrity": "sha512-cBBXHzuPtQK6wNthuVMV6IjHAFkdl/FOPFIlkd81/Cd1+IqkHu/A+w4g43kaQQoYHik/ruaQBDL72HyCy1vuMw==",
+      "version": "18.2.58",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.58.tgz",
+      "integrity": "sha512-TaGvMNhxvG2Q0K0aYxiKfNDS5m5ZsoIBBbtfUorxdH4NGSXIlYvZxLJI+9Dd3KjeB3780bciLyAb7ylO8pLhPw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -6203,9 +6605,9 @@
       "peer": true
     },
     "node_modules/arg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
-      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "peer": true
     },
     "node_modules/argparse": {
@@ -6509,6 +6911,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz",
       "integrity": "sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==",
+      "dev": true,
       "dependencies": {
         "find-babel-config": "^2.0.0",
         "glob": "^8.0.3",
@@ -6524,6 +6927,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -6532,6 +6936,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6550,6 +6955,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -6644,19 +7050,29 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-9.5.2.tgz",
-      "integrity": "sha512-hU1G1TDiikuXV6UDZjPnX+WdbjbtidDiYhftMEVrZQSst45pDPVBWbM41TUKrpJMwv4FypsLzK+378gnMPRVWQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-10.0.1.tgz",
+      "integrity": "sha512-uWIGmLfbP3dS5+8nesxaW6mQs41d4iP7X82ZwRdisB/wAhKQmuJM9Y1jQe4006uNYkw6Phf2TT03ykLVro7KuQ==",
       "peer": true,
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.12.9",
-        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
-        "@babel/plugin-proposal-object-rest-spread": "^7.12.13",
-        "@babel/plugin-transform-react-jsx": "^7.12.17",
+        "@babel/plugin-transform-export-namespace-from": "^7.22.11",
+        "@babel/plugin-transform-object-rest-spread": "^7.12.13",
+        "@babel/plugin-transform-parameters": "^7.22.15",
         "@babel/preset-env": "^7.20.0",
-        "babel-plugin-module-resolver": "^5.0.0",
+        "@babel/preset-react": "^7.22.15",
+        "@react-native/babel-preset": "^0.73.18",
         "babel-plugin-react-native-web": "~0.18.10",
-        "metro-react-native-babel-preset": "0.76.8"
+        "react-refresh": "0.14.0"
+      }
+    },
+    "node_modules/babel-preset-expo/node_modules/react-refresh": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/babel-preset-fbjs": {
@@ -6796,45 +7212,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
       "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
-      "peer": true
-    },
-    "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-      "peer": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "peer": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "peer": true
     },
     "node_modules/bplist-creator": {
@@ -7001,15 +7378,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/cacache": {
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
@@ -7088,6 +7456,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
       "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.1",
@@ -7235,6 +7604,65 @@
       "peer": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chrome-launcher": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+      "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chromium-edge-launcher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz",
+      "integrity": "sha512-pgtgjNKZ7i5U++1g1PWv75umkHvhVTDOQIZ+sjeUX9483S7Y6MUvO0lrd7ShGlQlFHMN4SwKTCq/X8hWrbv2KA==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ci-info": {
@@ -7395,11 +7823,6 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "peer": true
     },
-    "node_modules/compare-versions": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
-    },
     "node_modules/component-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.2.tgz",
@@ -7497,15 +7920,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "peer": true
-    },
-    "node_modules/content-type": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -8044,6 +8458,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
       "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.1",
         "gopd": "^1.0.1",
@@ -8494,7 +8909,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -9202,89 +9616,79 @@
       }
     },
     "node_modules/expo": {
-      "version": "49.0.20",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-49.0.20.tgz",
-      "integrity": "sha512-2j3GjnGlaLqpk7tzCnII9Ywxb64YZSp73n2U7TrZIWFxC5kwPCdejEYSqIYX+5ZzTJ1m8wmi23aB2BrH3Nzmzw==",
+      "version": "50.0.7",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-50.0.7.tgz",
+      "integrity": "sha512-lTqIrKOUTKHLdTuAaJzZihi1v7F8Ix1dOXVWMpToDy9zPC/s+fet0fbyXdFUxYsCUyuEDIB9tvejrTYZk8Hm0Q==",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.10.15",
-        "@expo/config": "8.1.2",
-        "@expo/config-plugins": "7.2.5",
-        "@expo/vector-icons": "^13.0.0",
-        "babel-preset-expo": "~9.5.2",
-        "expo-application": "~5.3.0",
-        "expo-asset": "~8.10.1",
-        "expo-constants": "~14.4.2",
-        "expo-file-system": "~15.4.5",
-        "expo-font": "~11.4.0",
-        "expo-keep-awake": "~12.3.0",
-        "expo-modules-autolinking": "1.5.1",
-        "expo-modules-core": "1.5.12",
+        "@expo/cli": "0.17.5",
+        "@expo/config": "8.5.4",
+        "@expo/config-plugins": "7.8.4",
+        "@expo/metro-config": "0.17.4",
+        "@expo/vector-icons": "^14.0.0",
+        "babel-preset-expo": "~10.0.1",
+        "expo-asset": "~9.0.2",
+        "expo-file-system": "~16.0.6",
+        "expo-font": "~11.10.3",
+        "expo-keep-awake": "~12.8.2",
+        "expo-modules-autolinking": "1.10.3",
+        "expo-modules-core": "1.11.9",
         "fbemitter": "^3.0.0",
-        "invariant": "^2.2.4",
-        "md5-file": "^3.2.3",
-        "node-fetch": "^2.6.7",
-        "pretty-format": "^26.5.2",
-        "uuid": "^3.4.0"
+        "whatwg-url-without-unicode": "8.0.0-3"
       },
       "bin": {
         "expo": "bin/cli"
       }
     },
-    "node_modules/expo-application": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-5.3.1.tgz",
-      "integrity": "sha512-HR2+K+Hm33vLw/TfbFaHrvUbRRNRco8R+3QaCKy7eJC2LFfT05kZ15ynGaKfB5DJ/oqPV3mxXVR/EfwmE++hoA==",
-      "peer": true,
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
     "node_modules/expo-asset": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-8.10.1.tgz",
-      "integrity": "sha512-5VMTESxgY9GBsspO/esY25SKEa7RyascVkLe/OcL1WgblNFm7xCCEEUIW8VWS1nHJQGYxpMZPr3bEfjMpdWdyA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-9.0.2.tgz",
+      "integrity": "sha512-PzYKME1MgUOoUvwtdzhAyXkjXOXGiSYqGKG/MsXwWr0Ef5wlBaBm2DCO9V6KYbng5tBPFu6hTjoRNil1tBOSow==",
       "peer": true,
       "dependencies": {
+        "@react-native/assets-registry": "~0.73.1",
         "blueimp-md5": "^2.10.0",
-        "expo-constants": "~14.4.2",
-        "expo-file-system": "~15.4.0",
+        "expo-constants": "~15.4.0",
+        "expo-file-system": "~16.0.0",
         "invariant": "^2.2.4",
-        "md5-file": "^3.2.3",
-        "path-browserify": "^1.0.0",
-        "url-parse": "^1.5.9"
+        "md5-file": "^3.2.3"
+      }
+    },
+    "node_modules/expo-asset/node_modules/@react-native/assets-registry": {
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.73.1.tgz",
+      "integrity": "sha512-2FgAbU7uKM5SbbW9QptPPZx8N9Ke2L7bsHb+EhAanZjFZunA9PaYtyjUQ1s7HD+zDVqOQIvjkpXSv7Kejd2tqg==",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/expo-constants": {
-      "version": "14.4.2",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-14.4.2.tgz",
-      "integrity": "sha512-nOB122DOAjk+KrJT69lFQAoYVQGQjFHSigCPVBzVdko9S1xGsfiOH9+X5dygTsZTIlVLpQJDdmZ7ONiv3i+26w==",
+      "version": "15.4.5",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-15.4.5.tgz",
+      "integrity": "sha512-1pVVjwk733hbbIjtQcvUFCme540v4gFemdNlaxM2UXKbfRCOh2hzgKN5joHMOysoXQe736TTUrRj7UaZI5Yyhg==",
       "peer": true,
       "dependencies": {
-        "@expo/config": "~8.1.0",
-        "uuid": "^3.3.2"
+        "@expo/config": "~8.5.0"
       },
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-file-system": {
-      "version": "15.4.5",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-15.4.5.tgz",
-      "integrity": "sha512-xy61KaTaDgXhT/dllwYDHm3ch026EyO8j4eC6wSVr/yE12MMMxAC09yGwy4f7kkOs6ztGVQF5j7ldRzNLN4l0Q==",
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-16.0.6.tgz",
+      "integrity": "sha512-ATCHL7nEg2WwKeamW/SDTR9jBEqM5wncFq594ftKS5QFmhKIrX48d9jyPFGnNq+6h8AGPg4QKh2KCA4OY49L4g==",
       "peer": true,
-      "dependencies": {
-        "uuid": "^3.4.0"
-      },
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-font": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-11.4.0.tgz",
-      "integrity": "sha512-nkmezCFD7gR/I6R+e3/ry18uEfF8uYrr6h+PdBJu+3dawoLOpo+wFb/RG9bHUekU1/cPanR58LR7G5MEMKHR2w==",
+      "version": "11.10.3",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-11.10.3.tgz",
+      "integrity": "sha512-q1Td2zUvmLbCA9GV4OG4nLPw5gJuNY1VrPycsnemN1m8XWTzzs8nyECQQqrcBhgulCgcKZZJJ6U0kC2iuSoQHQ==",
       "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
@@ -9294,9 +9698,9 @@
       }
     },
     "node_modules/expo-keep-awake": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-12.3.0.tgz",
-      "integrity": "sha512-ujiJg1p9EdCOYS05jh5PtUrfiZnK0yyLy+UewzqrjUqIT8eAGMQbkfOn3C3fHE7AKd5AefSMzJnS3lYZcZYHDw==",
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-12.8.2.tgz",
+      "integrity": "sha512-uiQdGbSX24Pt8nGbnmBtrKq6xL/Tm3+DuDRGBk/3ZE/HlizzNosGRIufIMJ/4B4FRw4dw8KU81h2RLuTjbay6g==",
       "peer": true,
       "peerDependencies": {
         "expo": "*"
@@ -9364,12 +9768,12 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.5.1.tgz",
-      "integrity": "sha512-yt5a1VCp2BF9CrsO689PCD5oXKP14MMhnOanQMvDn4BDpURYfzAlDVGC5fZrNQKtwn/eq3bcrxIwZ7D9QjVVRg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.10.3.tgz",
+      "integrity": "sha512-pn4n2Dl4iRh/zUeiChjRIe1C7EqOw1qhccr85viQV7W6l5vgRpY0osE51ij5LKg/kJmGRcJfs12+PwbdTplbKw==",
       "peer": true,
       "dependencies": {
-        "@expo/config": "~8.1.0",
+        "@expo/config": "~8.5.0",
         "chalk": "^4.1.0",
         "commander": "^7.2.0",
         "fast-glob": "^3.2.5",
@@ -9426,11 +9830,10 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "1.5.12",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.5.12.tgz",
-      "integrity": "sha512-mY4wTDU458dhwk7IVxLNkePlYXjs9BTgk4NQHBUXf0LapXsvr+i711qPZaFNO4egf5qq6fQV+Yfd/KUguHstnQ==",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.11.9.tgz",
+      "integrity": "sha512-GTUb81vcPaF+5MtlBI1u9IjrZbGdF1ZUwz3u8Gc+rOLBblkZ7pYsj2mU/tu+k0khTckI9vcH4ZBksXWvE1ncjQ==",
       "dependencies": {
-        "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"
       }
     },
@@ -9622,6 +10025,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.0.0.tgz",
       "integrity": "sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==",
+      "dev": true,
       "dependencies": {
         "json5": "^2.1.1",
         "path-exists": "^4.0.0"
@@ -9946,6 +10350,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
       "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
@@ -10086,6 +10491,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -10149,6 +10555,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
       "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.2"
       },
@@ -10160,6 +10567,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -10171,6 +10579,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -10346,18 +10755,6 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -11793,12 +12190,6 @@
         "xml2js": "0.6.0"
       }
     },
-    "node_modules/jest-expo/node_modules/@expo/config-types": {
-      "version": "50.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-50.0.0-alpha.3.tgz",
-      "integrity": "sha512-dzJ49GOqFxcJX8WMn4zNc7ffEQEgJ93EfhwQZ6BHqkCgvnnkoBl8sO0a8Y+UzLCD1nGOV6j3vLvzLyRkD6buaA==",
-      "dev": true
-    },
     "node_modules/jest-expo/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -12862,6 +13253,31 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lighthouse-logger": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+      "peer": true,
+      "dependencies": {
+        "debug": "^2.6.9",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "peer": true
+    },
     "node_modules/lightningcss": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.19.0.tgz",
@@ -13364,6 +13780,12 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/marky": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
+      "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
+      "peer": true
+    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -13395,15 +13817,6 @@
       "resolved": "https://registry.npmjs.org/md5hex/-/md5hex-1.0.0.tgz",
       "integrity": "sha512-c2YOUbp33+6thdCUi34xIyOU/a7bvGKj/3DB1iaPMTuPHf/Q2d5s4sn1FaCOO43XkXggnb08y5W2PU8UNYNLKQ==",
       "peer": true
-    },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -14139,9 +14552,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
-      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -14518,6 +14931,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -15029,12 +15443,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "peer": true
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -15177,6 +15585,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
       "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
       "dependencies": {
         "find-up": "^3.0.0"
       },
@@ -15188,6 +15597,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -15199,6 +15609,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -15211,6 +15622,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -15225,6 +15637,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -15236,6 +15649,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -15279,9 +15693,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
       "funding": [
         {
           "type": "opencollective",
@@ -15298,7 +15712,7 @@
       ],
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -15473,7 +15887,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -15504,25 +15917,11 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
-    "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "peer": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -15559,21 +15958,6 @@
       "peer": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "peer": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/rc": {
@@ -16013,12 +16397,14 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/reselect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -16061,7 +16447,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
       "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -16328,7 +16713,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/sax": {
       "version": "1.3.0",
@@ -16452,33 +16838,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/serialize-error": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-6.0.0.tgz",
-      "integrity": "sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==",
-      "peer": true,
-      "dependencies": {
-        "type-fest": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
-      "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -16504,6 +16863,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
       "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.1",
         "get-intrinsic": "^1.2.1",
@@ -16584,6 +16944,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -17423,10 +17784,13 @@
       }
     },
     "node_modules/traverse": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
-      "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
+      "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
       "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -17559,19 +17923,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "peer": true,
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -17860,6 +18211,7 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -17890,13 +18242,12 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "peer": true,
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -18032,6 +18383,29 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url-without-unicode": {
+      "version": "8.0.0-3",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
+      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
+      "peer": true,
+      "dependencies": {
+        "buffer": "^5.4.3",
+        "punycode": "^2.1.1",
+        "webidl-conversions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/whatwg-url-without-unicode/node_modules/webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,17 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@moneykit/connect-react-native",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
-      "dependencies": {
-        "expo-modules-core": "~1.5.10"
-      },
       "devDependencies": {
-        "@types/react": "~18.2.45",
-        "expo-module-scripts": "^3.0.11",
-        "expo-modules-core": "^1.5.11"
+        "@types/react": "^18.0.25",
+        "expo-module-scripts": "^3.4.0",
+        "expo-modules-core": "^1.11.2"
       },
       "peerDependencies": {
         "expo": "^50.0.7",
@@ -1800,7 +1797,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz",
       "integrity": "sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.22.5"
       },
@@ -1843,7 +1839,6 @@
       "version": "7.23.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.23.3.tgz",
       "integrity": "sha512-qMFdSS+TUhB7Q/3HVPnEdYJDQIk57jkntAwSuz9xfSE4n+3I+vHYCli3HoHawN1Z3RfCz/y1zXA/JXjG6cVImQ==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -2163,7 +2158,6 @@
       "version": "7.23.3",
       "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.23.3.tgz",
       "integrity": "sha512-7yn6hl8RIv+KNk6iIrGZ+D06VhVY35wLVf23Cz/mMu1zOr7u4MMP4j0nZ9tLf8+4ZFpnib8cFYgB/oYg9hfswA==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-validator-option": "^7.22.15",
@@ -2193,7 +2187,6 @@
       "version": "7.23.3",
       "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.23.3.tgz",
       "integrity": "sha512-tbkHOS9axH6Ysf2OUEqoSZ6T3Fa2SrNH6WTWSPBboxKzdxNc9qOICeLXkNG0ZEwbQ1HY8liwOce4aN/Ceyuq6w==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-validator-option": "^7.22.15",
@@ -2213,7 +2206,6 @@
       "version": "7.23.3",
       "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.23.3.tgz",
       "integrity": "sha512-17oIGVlqz6CchO9RFYn5U6ZpWRZIngayYCtrPRSgANSwC2V1Jb+iP74nVxzzXJte8b8BYxrL1yY96xfhTBrNNQ==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-validator-option": "^7.22.15",
@@ -2232,7 +2224,6 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.15.tgz",
       "integrity": "sha512-V3Q3EqoQdn65RCgTLwauZaTfd1ShhwPmbBv+1dkZV/HpCGMKVyn6oFcRlI7RaKqiDQjX2Qd3AuoEguBgdjIKlg==",
-      "peer": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
         "find-cache-dir": "^2.0.0",
@@ -2251,7 +2242,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -5632,7 +5622,6 @@
       "version": "0.73.4",
       "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.73.4.tgz",
       "integrity": "sha512-XzRd8MJGo4Zc5KsphDHBYJzS1ryOHg8I2gOZDAUCGcwLFhdyGu1zBNDJYH2GFyDrInn9TzAbRIf3d4O+eltXQQ==",
-      "peer": true,
       "dependencies": {
         "@react-native/codegen": "0.73.3"
       },
@@ -5644,7 +5633,6 @@
       "version": "0.73.3",
       "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.73.3.tgz",
       "integrity": "sha512-sxslCAAb8kM06vGy9Jyh4TtvjhcP36k/rvj2QE2Jdhdm61KvfafCATSIsOfc0QvnduWFcpXUPvAVyYwuv7PYDg==",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.0",
         "flow-parser": "^0.206.0",
@@ -5665,7 +5653,6 @@
       "version": "0.73.21",
       "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.73.21.tgz",
       "integrity": "sha512-WlFttNnySKQMeujN09fRmrdWqh46QyJluM5jdtDNrkl/2Hx6N4XeDUGhABvConeK95OidVO7sFFf7sNebVXogA==",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
@@ -5721,7 +5708,6 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5938,10 +5924,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
+      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -6757,7 +6743,6 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
       "integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -6825,7 +6810,6 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "peer": true,
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
@@ -6849,6 +6833,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+      "dev": true,
+      "dependencies": {
+        "object.assign": "^4.1.0"
       }
     },
     "node_modules/babel-plugin-istanbul": {
@@ -6905,62 +6898,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/babel-plugin-module-resolver": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz",
-      "integrity": "sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==",
-      "dev": true,
-      "dependencies": {
-        "find-babel-config": "^2.0.0",
-        "glob": "^8.0.3",
-        "pkg-up": "^3.1.0",
-        "reselect": "^4.1.7",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/babel-plugin-module-resolver/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/babel-plugin-module-resolver/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/babel-plugin-module-resolver/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -7053,7 +6990,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-10.0.1.tgz",
       "integrity": "sha512-uWIGmLfbP3dS5+8nesxaW6mQs41d4iP7X82ZwRdisB/wAhKQmuJM9Y1jQe4006uNYkw6Phf2TT03ykLVro7KuQ==",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.12.9",
         "@babel/plugin-transform-export-namespace-from": "^7.22.11",
@@ -7070,7 +7006,6 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7354,8 +7289,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "peer": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/builtins": {
       "version": "1.0.3",
@@ -7746,7 +7680,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "peer": true,
       "dependencies": {
         "is-plain-object": "^2.0.4",
         "kind-of": "^6.0.2",
@@ -7820,8 +7753,7 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "peer": true
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
     "node_modules/component-type": {
       "version": "1.2.2",
@@ -9707,17 +9639,21 @@
       }
     },
     "node_modules/expo-module-scripts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/expo-module-scripts/-/expo-module-scripts-3.1.0.tgz",
-      "integrity": "sha512-xVv/Tz2XaPRQ69kZmnm9XiaQekLhXMgwxGoerYFygi7f/naPr3ZgKWVE9e2+CpSk+gyMRLqVL+vjLW/i7xVaRQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/expo-module-scripts/-/expo-module-scripts-3.4.1.tgz",
+      "integrity": "sha512-06VQMqcj39kvvkIsllDZ/nvzAy7YRp05nx+x1nR6AW1kYvwYQkQCeHckaZL8szxoZieYSWDG3NFk+c0b0G5cTg==",
       "dev": true,
       "dependencies": {
         "@babel/cli": "^7.1.2",
+        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
+        "@babel/preset-env": "^7.20.2",
+        "@babel/preset-typescript": "^7.12.12",
         "@expo/npm-proofread": "^1.0.1",
         "@testing-library/react-hooks": "^7.0.1",
-        "@tsconfig/node14": "^1.0.3",
+        "@tsconfig/node18": "^18.2.2",
         "@types/jest": "^29.2.1",
-        "babel-preset-expo": "~9.6.0",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "babel-preset-expo": "~10.0.0",
         "commander": "^2.19.0",
         "eslint-config-universe": "^12.0.0",
         "find-yarn-workspace-root": "^2.0.0",
@@ -9729,22 +9665,6 @@
       },
       "bin": {
         "expo-module": "bin/expo-module.js"
-      }
-    },
-    "node_modules/expo-module-scripts/node_modules/babel-preset-expo": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-9.6.2.tgz",
-      "integrity": "sha512-Ukrf1GV1s1D101DbZapvihGvKM1hb1Sj/xYGBqE+dxY3ZBIDQQxbev5vjOxOOlaFnW5c4Ui0+R5byMt19F+3Qg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/plugin-proposal-decorators": "^7.12.9",
-        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
-        "@babel/plugin-proposal-object-rest-spread": "^7.12.13",
-        "@babel/plugin-transform-react-jsx": "^7.12.17",
-        "@babel/preset-env": "^7.20.0",
-        "babel-plugin-module-resolver": "^5.0.0",
-        "babel-plugin-react-native-web": "~0.18.10",
-        "metro-react-native-babel-preset": "0.76.8"
       }
     },
     "node_modules/expo-module-scripts/node_modules/glob": {
@@ -10021,24 +9941,10 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/find-babel-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.0.0.tgz",
-      "integrity": "sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==",
-      "dev": true,
-      "dependencies": {
-        "json5": "^2.1.1",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/find-cache-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-      "peer": true,
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^2.0.0",
@@ -10052,7 +9958,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "peer": true,
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -10064,7 +9969,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "peer": true,
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -10077,7 +9981,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -10092,7 +9995,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "peer": true,
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -10104,7 +10006,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10113,7 +10014,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "peer": true,
       "dependencies": {
         "find-up": "^3.0.0"
       },
@@ -10192,7 +10092,6 @@
       "version": "0.206.0",
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.206.0.tgz",
       "integrity": "sha512-HVzoK3r6Vsg+lKvlIZzaWNBVai+FXTX1wdYhz/wVlH13tb/gOdLXmlTqy6odmTBhT5UoWUbq0k8263Qhr9d88w==",
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -11298,7 +11197,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "peer": true,
       "dependencies": {
         "isobject": "^3.0.1"
       },
@@ -11487,7 +11385,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13005,7 +12902,6 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.14.0.tgz",
       "integrity": "sha512-7eCC1knD7bLUPuSCwXsMZUH51O8jIcoVyKtI6P0XM0IVzlGjckPy3FIwQlorzbN0Sg79oK+RlohN32Mqf/lrYA==",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.13.16",
         "@babel/parser": "^7.13.16",
@@ -13217,7 +13113,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14191,6 +14086,7 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.76.8.tgz",
       "integrity": "sha512-Ptza08GgqzxEdK8apYsjTx2S8WDUlS2ilBlu9DR1CUcHmg4g3kOkFylZroogVAUKtpYQNYwAvdsjmrSdDNtiAg==",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
@@ -14628,7 +14524,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -14742,8 +14637,7 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "peer": true
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/nested-error-stacks": {
       "version": "2.0.1",
@@ -14775,7 +14669,6 @@
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
       "integrity": "sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==",
-      "peer": true,
       "dependencies": {
         "minimatch": "^3.0.2"
       },
@@ -14901,8 +14794,7 @@
     "node_modules/nullthrows": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
-      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
-      "peer": true
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
     },
     "node_modules/nwsapi": {
       "version": "2.2.7",
@@ -15581,79 +15473,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-up/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -16129,6 +15948,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
       "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16218,7 +16038,6 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.21.5.tgz",
       "integrity": "sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==",
-      "peer": true,
       "dependencies": {
         "ast-types": "0.15.2",
         "esprima": "~4.0.0",
@@ -16398,12 +16217,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
-    },
-    "node_modules/reselect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
       "dev": true
     },
     "node_modules/resolve": {
@@ -16904,7 +16717,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "peer": true,
       "dependencies": {
         "kind-of": "^6.0.2"
       },
@@ -17513,7 +17325,6 @@
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
       "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
-      "peer": true,
       "dependencies": {
         "rimraf": "~2.6.2"
       },
@@ -17534,7 +17345,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "MoneyKit Connect is a quick and secure way to link bank accounts from within your app. The drop-in framework handles connecting to a financial institution in your app (credential validation, multi-factor authentication, error handling, etc.) without passing sensitive information to your server",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -28,14 +28,13 @@
   "author": "MoneyKit <info@moneykit.com> (https://github.com/moneykit)",
   "license": "MIT",
   "homepage": "https://github.com/moneykit/moneykit-react-native#readme",
-  "dependencies": {},
   "devDependencies": {
     "@types/react": "^18.0.25",
     "expo-module-scripts": "^3.4.0",
     "expo-modules-core": "^1.11.2"
   },
   "peerDependencies": {
-    "expo": "*",
+    "expo": "^50.0.7",
     "react": "*",
     "react-native": "*"
   }

--- a/package.json
+++ b/package.json
@@ -28,13 +28,11 @@
   "author": "MoneyKit <info@moneykit.com> (https://github.com/moneykit)",
   "license": "MIT",
   "homepage": "https://github.com/moneykit/moneykit-react-native#readme",
-  "dependencies": {
-    "expo-modules-core": "~1.5.10"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/react": "^18.0.25",
-    "expo-module-scripts": "^3.0.11",
-    "expo-modules-core": "^1.5.11"
+    "expo-module-scripts": "^3.4.0",
+    "expo-modules-core": "^1.11.2"
   },
   "peerDependencies": {
     "expo": "*",


### PR DESCRIPTION
This PR makes a few updates:

- Updates the iOS SDK to the [latest release](https://github.com/moneykit/moneykit-ios/releases/tag/1.5.0).
- Update the Expo SDK to the [latest version](https://www.npmjs.com/package/expo/v/50.0.7)
- Removes the dependency on the `expo-modules-core` which should resolve [dependency conflicts](https://github.com/moneykit/moneykit-react-native/issues/22)