### PR TITLE
Increase version to 1.7.0: Android fixes for expo 50

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,13 +53,16 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 34)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
   }
 
   namespace "expo.modules.moneykitconnectreactnative"
@@ -67,7 +70,7 @@ android {
     minSdkVersion safeExtGet("minSdkVersion", 26)
     targetSdkVersion safeExtGet("targetSdkVersion", 34)
     versionCode 1
-    versionName "0.1.0"
+    versionName "<%- project.version %>"
   }
   lintOptions {
     abortOnError false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "MoneyKit Connect is a quick and secure way to link bank accounts from within your app. The drop-in framework handles connecting to a financial institution in your app (credential validation, multi-factor authentication, error handling, etc.) without passing sensitive information to your server",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Expo v50 had some required changes for Android configs in Expo modules:

> **If you maintain any Expo Modules:**
> - For Android: update your library build.gradle to match the changes in [this diff](https://gist.github.com/brentvatne/61cd1a938fb4ba8869bc490647aa52e8). You may also now remove the JVM target version configuration, [as explained in this FYI page](https://expo.fyi/expo-modules-gradle8-migration#error-task-current-target-is-17-and-compilereleasekotlin-task-current-target-is-11-jvm-target-compatibility-should-be-set-to-the-same-java-version).

https://expo.dev/changelog/2024/01-18-sdk-50

This PR implements these changes and updates the module version to 1.7.0.