### PR TITLE
Update Android SDK to 0.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -89,5 +89,5 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation "com.moneykit:connect:0.0.7"
+  implementation "com.moneykit:connect:0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "MoneyKit Connect is a quick and secure way to link bank accounts from within your app. The drop-in framework handles connecting to a financial institution in your app (credential validation, multi-factor authentication, error handling, etc.) without passing sensitive information to your server",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
This bumps the React Native SDK to version 1.11.0 and also updates to the [latest Android SDK](https://central.sonatype.com/artifact/com.moneykit/connect/0.1.0/versions)