### PR TITLE
fix: bump min sdk to 26

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -35,6 +35,9 @@
         {
           "ios": {
             "deploymentTarget": "14.0"
+          },
+          "android": { 
+            "minSdkVersion": 26
           }
         }
       ]


### PR DESCRIPTION
This PR fixes build issues for Android example app. 

Without this minSdkVersion bump I wasn't able to build the app 