### PR TITLE
feat: properly format token in payload

### DIFF
--- a/android/src/main/java/expo/modules/moneykitconnectreactnativesource/ConnectModule.kt
+++ b/android/src/main/java/expo/modules/moneykitconnectreactnativesource/ConnectModule.kt
@@ -120,7 +120,9 @@ class ConnectModule : Module() {
       "id" to institution.id,
       "name" to institution.name,
     ),
-    "token" to token.value,
+    "token" to mapOf(
+      "value" to token.value
+    ),
     "accounts" to accounts.map { account ->
       mapOf(
         "id" to account.id,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "1.16.0",
+  "version": "1.2.0",
   "description": "MoneyKit Connect is a quick and secure way to link bank accounts from within your app. The drop-in framework handles connecting to a financial institution in your app (credential validation, multi-factor authentication, error handling, etc.) without passing sensitive information to your server",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
This PR properly formats token in the onSuccess event payload. 

This is a **breaking change** so we will need to release a version with bigger bump probably 1.2.0.

Now the approach is unified for both platforms where the `token` field contains `value` field.