### PR TITLE
Bump iOS SDK to 1.9.3

### DIFF
--- a/ios/Connect.podspec
+++ b/ios/Connect.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MoneyKit', '~> 1.9.2'
+  s.dependency 'MoneyKit', '~> 1.9.3'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "MoneyKit Connect is a quick and secure way to link bank accounts from within your app. The drop-in framework handles connecting to a financial institution in your app (credential validation, multi-factor authentication, error handling, etc.) without passing sensitive information to your server",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
This points the React Native SDK to the latest release of the [MoneyKit iOS SDK](https://github.com/moneykit/moneykit-ios/releases/tag/1.9.3)