### PR TITLE
S15 201 mandatory android and moneykit sdk bump

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,8 +25,8 @@ if (useManagedAndroidSdkVersions) {
   project.android {
     compileSdkVersion safeExtGet("compileSdkVersion", 34)
     defaultConfig {
-      minSdkVersion safeExtGet("minSdkVersion", 21)
-      targetSdkVersion safeExtGet("targetSdkVersion", 34)
+      minSdkVersion safeExtGet("minSdkVersion", 23)
+      targetSdkVersion safeExtGet("targetSdkVersion", 35)
     }
   }
 }
@@ -43,5 +43,5 @@ android {
 }
 
 dependencies {
-  implementation "com.moneykit:connect:0.4.1"
+  implementation "com.moneykit:connect:0.4.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@moneykit/connect-react-native",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.0.25",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moneykit/connect-react-native",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "MoneyKit Connect is a quick and secure way to link bank accounts from within your app. The drop-in framework handles connecting to a financial institution in your app (credential validation, multi-factor authentication, error handling, etc.) without passing sensitive information to your server",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Update Android targetSdkVersion to 35, update MoneyKit Connect SDK dependency to latest 0.4.2.